### PR TITLE
Easy to use patch: Numbers don't have to be consecutive

### DIFF
--- a/calib_intrinsic.cpp
+++ b/calib_intrinsic.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <iostream>
 #include "popt_pp.h"
+#include <sys/stat.h>
 
 using namespace std;
 using namespace cv;
@@ -17,6 +18,11 @@ vector< vector< Point2f > > left_img_points;
 Mat img, gray;
 Size im_size;
 
+bool doesExist (const std::string& name) {
+  struct stat buffer;   
+  return (stat (name.c_str(), &buffer) == 0); 
+}
+
 void setup_calibration(int board_width, int board_height, int num_imgs, 
                        float square_size, char* imgs_directory, char* imgs_filename,
                        char* extension) {
@@ -26,6 +32,8 @@ void setup_calibration(int board_width, int board_height, int num_imgs,
   for (int k = 1; k <= num_imgs; k++) {
     char img_file[100];
     sprintf(img_file, "%s%s%d.%s", imgs_directory, imgs_filename, k, extension);
+    if(!doesExist(img_file))
+      continue;
     img = imread(img_file, CV_LOAD_IMAGE_COLOR);
     cv::cvtColor(img, gray, CV_BGR2GRAY);
 

--- a/calib_stereo.cpp
+++ b/calib_stereo.cpp
@@ -38,6 +38,13 @@ void load_image_points(int board_width, int board_height, int num_imgs, float sq
     found2 = cv::findChessboardCorners(img2, board_size, corners2,
   CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FILTER_QUADS);
 
+
+    if(!found1 || !found2){
+      cout << "Chessboard find error!" << endl;
+      cout << "leftImg: " << left_img << " and rightImg: " << right_img <<endl;
+      continue;
+    } 
+
     if (found1)
     {
       cv::cornerSubPix(gray1, corners1, cv::Size(5, 5), cv::Size(-1, -1),


### PR DESCRIPTION
For calib_intrinsic I had problem. Sometimes my left{x}.png image if blurry etc. For that I added a part that so the number iterations shouldn't be consecutive. Also in stereo calibration sometimes it is possible image quality is bad and chessboard is not found. For that I added a part so it will give an error.