### PR TITLE
Add handling for image file extension 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ For example, the command for the test images in `calib_imgs/1/` would be
 Once you have the intrinsics calibrated for both the left and the right cameras, you can use their intrinsics to calibrate the extrinsics between them.
 
 ```bash
-./calibrate_stereo -n [num_imgs] -u [left_cam_calib] -v [right_cam_calib] -L [left_img_dir] -R [right_img_dir] -l [left_img_prefix] -r [right_img_prefix] -o [output_calib_file]
+./calibrate_stereo -n [num_imgs] -u [left_cam_calib] -v [right_cam_calib] -L [left_img_dir] -R [right_img_dir] -l [left_img_prefix] -r [right_img_prefix] -o [output_calib_file] -e [file_extension]
 ```
 
 For example, if you calibrated the left and the right cameras using the images in the `calib_imgs/1/` directory, the following command to compute the extrinsics.
 
 ```bash
-./calibrate_stereo -n 27 -u cam_left.yml -v cam_right.yml -L ../calib_imgs/1/ -R ../calib_imgs/1/ -l left -r right -o cam_stereo.yml
+./calibrate_stereo -n 27 -u cam_left.yml -v cam_right.yml -L ../calib_imgs/1/ -R ../calib_imgs/1/ -l left -r right -o cam_stereo.yml -e jpg
 ```
 
 ### Undistortion and Rectification

--- a/calib_stereo.cpp
+++ b/calib_stereo.cpp
@@ -17,15 +17,15 @@ vector< vector< Point2f > > left_img_points, right_img_points;
 Mat img1, img2, gray1, gray2;
 
 void load_image_points(int board_width, int board_height, int num_imgs, float square_size,
-                      char* leftimg_dir, char* rightimg_dir, char* leftimg_filename, char* rightimg_filename) {
+                      char* leftimg_dir, char* rightimg_dir, char* leftimg_filename, char* rightimg_filename, char* extension) {
 
   Size board_size = Size(board_width, board_height);
   int board_n = board_width * board_height;
 
   for (int i = 1; i <= num_imgs; i++) {
     char left_img[100], right_img[100];
-    sprintf(left_img, "%s%s%d.jpg", leftimg_dir, leftimg_filename, i);
-    sprintf(right_img, "%s%s%d.jpg", rightimg_dir, rightimg_filename, i);
+    sprintf(left_img, "%s%s%d.%s", leftimg_dir, leftimg_filename, i, extension);
+    sprintf(right_img, "%s%s%d.%s", rightimg_dir, rightimg_filename, i, extension);
     img1 = imread(left_img, CV_LOAD_IMAGE_COLOR);
     img2 = imread(right_img, CV_LOAD_IMAGE_COLOR);
     cvtColor(img1, gray1, CV_BGR2GRAY);
@@ -89,6 +89,7 @@ int main(int argc, char const *argv[])
   char* rightimg_dir;
   char* leftimg_filename;
   char* rightimg_filename;
+  char* extension;
   char* out_file;
   int num_imgs;
 
@@ -100,6 +101,7 @@ int main(int argc, char const *argv[])
     { "rightimg_dir",'R',POPT_ARG_STRING,&rightimg_dir,0,"Directory containing right images","STR" },
     { "leftimg_filename",'l',POPT_ARG_STRING,&leftimg_filename,0,"Left image prefix","STR" },
     { "rightimg_filename",'r',POPT_ARG_STRING,&rightimg_filename,0,"Right image prefix","STR" },
+    { "extension",'e',POPT_ARG_STRING,&extension,0,"Image extension","STR" },
     { "out_file",'o',POPT_ARG_STRING,&out_file,0,"Output calibration filename (YML)","STR" },
     POPT_AUTOHELP
     { NULL, 0, 0, NULL, 0, NULL, NULL }
@@ -113,7 +115,7 @@ int main(int argc, char const *argv[])
   FileStorage fsr(rightcalib_file, FileStorage::READ);
 
   load_image_points(fsl["board_width"], fsl["board_height"], num_imgs, fsl["square_size"],
-                   leftimg_dir, rightimg_dir, leftimg_filename, rightimg_filename);
+                   leftimg_dir, rightimg_dir, leftimg_filename, rightimg_filename, extension);
 
   printf("Starting Calibration\n");
   Mat K1, K2, R, F, E;


### PR DESCRIPTION
Hi,

The stereo calibration was not handling different file path. I added an identical flag to the monocular version. 